### PR TITLE
Bug Fix: When there is a 'No Matching Job Found' Program exits from u…

### DIFF
--- a/linkedin.py
+++ b/linkedin.py
@@ -72,8 +72,11 @@ class Linkedin:
 
         for url in urlData:        
             self.driver.get(url)
-
-            totalJobs = self.driver.find_element(By.XPATH,'//small').text 
+            try:
+                totalJobs = self.driver.find_element(By.XPATH,'//small').text 
+            except:
+                print("No Matching Jobs Found")
+                continue
             totalPages = utils.jobsToPages(totalJobs)
 
             urlWords =  utils.urlToKeywords(url)


### PR DESCRIPTION
…nhandled Exception

Cause: find_element
(By.XPATH,'//small'').text is not found in current page resulting in an element not found exception that is unhandled"